### PR TITLE
fix: log Map and Set instead of dropping them as empty objects

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,7 @@ export const DEFAULT_SERVICE = ''
 export const DEFAULT_CATEGORY = 'default'
 export const PRODUCTION_FORMATTER = 'json'
 export const DEFAULT_FORMATTER = 'dark'
+export const DEFAULT_JSON_MESSAGE_ITEMS_LIMIT = 10
 export const DEFAULT_MAX_CACHE_TIME_MS = 1000 * 60 * 60 * 24
 export const MIN_MAX_CACHE_TIME_MS = 1000 * 60 * 60 * 1
 export const DEFAULT_CHECK_CACHE_TIMEOUT_MS = 1000 * 10

--- a/src/message/__tests__/details.spec.ts
+++ b/src/message/__tests__/details.spec.ts
@@ -69,6 +69,59 @@ describe('details', () => {
     })
   })
 
+  describe('maps', () => {
+    it('empty list maps', () => {
+      expect(details.maps).toEqual(expect.any(Array))
+      expect(details.maps.length).toEqual(0)
+    })
+
+    it('incorrect type', () => {
+      // @ts-ignore
+      details.setMap({ a: 1 })
+      expect(details.maps.length).toEqual(0)
+    })
+
+    it('stores map as entry pairs', () => {
+      const map = new Map<any, any>([
+        ['a', 1],
+        ['b', 2],
+      ])
+      details.setMap(map)
+
+      expect(details.reserved._maps).toEqual([
+        [
+          ['a', 1],
+          ['b', 2],
+        ],
+      ])
+      expect(details.maps[0]).toEqual([
+        ['a', 1],
+        ['b', 2],
+      ])
+    })
+  })
+
+  describe('sets', () => {
+    it('empty list sets', () => {
+      expect(details.sets).toEqual(expect.any(Array))
+      expect(details.sets.length).toEqual(0)
+    })
+
+    it('incorrect type', () => {
+      // @ts-ignore
+      details.setSet([1, 2, 3])
+      expect(details.sets.length).toEqual(0)
+    })
+
+    it('stores set as value array', () => {
+      const set = new Set([1, 2, 3])
+      details.setSet(set)
+
+      expect(details.reserved._sets).toEqual([[1, 2, 3]])
+      expect(details.sets[0]).toEqual([1, 2, 3])
+    })
+  })
+
   describe('stacktraces', () => {
     it('empty list stacktraces', () => {
       expect(details.stacks).toEqual(expect.any(Array))

--- a/src/message/details.ts
+++ b/src/message/details.ts
@@ -11,6 +11,8 @@ interface IDetails {
   _timeRange?: TimeRange
   _depth?: number
   _module?: ModDetails
+  _maps?: [any, any][][]
+  _sets?: any[][]
 
   [key: string]: any
 }
@@ -48,6 +50,14 @@ export class Details {
     return this.reserved._module
   }
 
+  get maps() {
+    return this.reserved._maps || []
+  }
+
+  get sets() {
+    return this.reserved._sets || []
+  }
+
   get<T = any>(key: string): T | undefined {
     if (key in this.details) return this.details[key]
     if (key in this.hidden) return this.hidden[key]
@@ -82,6 +92,18 @@ export class Details {
     if (!(time instanceof TimeDetails)) return
     if (!this.reserved._times) this.reserved._times = []
     this.reserved._times.push(time)
+  }
+
+  setMap(map: Map<any, any>) {
+    if (!(map instanceof Map)) return
+    if (!this.reserved._maps) this.reserved._maps = []
+    this.reserved._maps.push(Array.from(map))
+  }
+
+  setSet(set: Set<any>) {
+    if (!(set instanceof Set)) return
+    if (!this.reserved._sets) this.reserved._sets = []
+    this.reserved._sets.push(Array.from(set))
   }
 
   setStacktrace(stack: string[], label?: string) {

--- a/src/utils/__tests__/json.formatter.spec.ts
+++ b/src/utils/__tests__/json.formatter.spec.ts
@@ -36,6 +36,20 @@ describe('JSON formatter', () => {
       expect(formatter.array([1, 2, 3])).toEqual(expect.any(String))
     })
 
+    it('map', () => {
+      expect(formatter.map(new Map([['a', 1]]))).toEqual(expect.any(String))
+    })
+
+    it('set', () => {
+      expect(formatter.set(new Set([1, 2, 3]))).toEqual(expect.any(String))
+    })
+
+    it('map and set limit elements in the message', () => {
+      const entries = Array.from({ length: formatter.maxArrayLength + 5 }, (_, i): [number, number] => [i, i])
+      expect(formatter.map(new Map(entries))).toMatch('more items')
+      expect(formatter.set(new Set(entries.map(([k]) => k)))).toMatch('more items')
+    })
+
     it('null', () => {
       expect(formatter.null(null)).toEqual(expect.any(String))
       expect(formatter.null(undefined)).toEqual(expect.any(String))
@@ -86,6 +100,27 @@ describe('JSON formatter', () => {
       const info = reader.read(meta, [StaticLogger.index('current index')])
       const obj = JSON.parse(formatter.format(info))
       expect(obj['@index']).toEqual(info.index)
+    })
+
+    it('nested Map and Set in details are serialized, not lost as {}', () => {
+      const info = reader.read(meta, [
+        {
+          data: new Map<any, any>([
+            ['a', 1],
+            ['b', 2],
+          ]),
+          tags: new Set([1, 2, 3]),
+          count: 5,
+        },
+      ])
+      const obj = JSON.parse(formatter.format(info))
+
+      expect(obj.details.data).toEqual([
+        ['a', 1],
+        ['b', 2],
+      ])
+      expect(obj.details.tags).toEqual([1, 2, 3])
+      expect(obj.details.count).toEqual(5)
     })
   })
 })

--- a/src/utils/__tests__/log.reader.spec.ts
+++ b/src/utils/__tests__/log.reader.spec.ts
@@ -68,6 +68,30 @@ describe('log reader', () => {
 
       expect(info.details.details).toEqual(expect.objectContaining(obj))
     })
+
+    it('Map value', () => {
+      const map = new Map<any, any>([
+        ['a', 1],
+        ['b', 2],
+      ])
+      const info = reader.read(meta, [map])
+      const str = stringFormatter.messages([stringFormatter.map(map)])
+
+      expect(info.message).toMatch(str)
+      expect(info.details.maps[0]).toEqual([
+        ['a', 1],
+        ['b', 2],
+      ])
+    })
+
+    it('Set value', () => {
+      const set = new Set([1, 2, 3])
+      const info = reader.read(meta, [set])
+      const str = stringFormatter.messages([stringFormatter.set(set)])
+
+      expect(info.message).toMatch(str)
+      expect(info.details.sets[0]).toEqual([1, 2, 3])
+    })
   })
 
   describe('error message', () => {

--- a/src/utils/__tests__/string.formatter.spec.ts
+++ b/src/utils/__tests__/string.formatter.spec.ts
@@ -113,6 +113,21 @@ describe('String formatter', () => {
     })
   })
 
+  describe('Map and Set', () => {
+    it('returns the raw value so formatWithOptions renders it', () => {
+      const map = new Map([['a', 1]])
+      const set = new Set([1, 2])
+      expect(formatter.map(map)).toBe(map)
+      expect(formatter.set(set)).toBe(set)
+    })
+
+    it('renders natively in the output', () => {
+      const str = format([new Map([['a', 1]]), new Set([1, 2])])
+      expect(str).toMatch('Map(1)')
+      expect(str).toMatch('Set(2)')
+    })
+  })
+
   describe('stacktraces', () => {
     it('errors traces', () => {
       const err = new Error('qwerty')

--- a/src/utils/json.formatter.ts
+++ b/src/utils/json.formatter.ts
@@ -1,7 +1,11 @@
+import { formatWithOptions } from 'util'
+import { DEFAULT_JSON_MESSAGE_ITEMS_LIMIT } from '../constants'
 import { LogInfo } from '../message/log.info'
 import { IFormatter } from './types'
 
 export class JsonFormatter implements IFormatter {
+  readonly maxArrayLength: number = DEFAULT_JSON_MESSAGE_ITEMS_LIMIT
+
   symbol(value: symbol): string {
     return value.toString()
   }
@@ -16,6 +20,14 @@ export class JsonFormatter implements IFormatter {
 
   array(value: any[]): string {
     return value.toString()
+  }
+  // maxArrayLength caps Array entries but not Map/Set entries, so render
+  // Array.from(...) to make the element limit actually apply to the message.
+  map(value: Map<any, any>): string {
+    return `Map(${value.size}) ${formatWithOptions({ maxArrayLength: this.maxArrayLength }, Array.from(value))}`
+  }
+  set(value: Set<any>): string {
+    return `Set(${value.size}) ${formatWithOptions({ maxArrayLength: this.maxArrayLength }, Array.from(value))}`
   }
   null(value: null | undefined): string {
     return `${value}`
@@ -38,12 +50,23 @@ export class JsonFormatter implements IFormatter {
   }
 
   format(info: LogInfo): string {
-    return JSON.stringify({
-      message: info.message,
-      meta: info.meta,
-      details: info.details.toJSON(),
-      '@timestamp': info.meta.timestamp,
-      '@index': info.index,
-    })
+    return JSON.stringify(
+      {
+        message: info.message,
+        meta: info.meta,
+        details: info.details.toJSON(),
+        '@timestamp': info.meta.timestamp,
+        '@index': info.index,
+      },
+      JsonFormatter.replacer,
+    )
+  }
+
+  // JSON.stringify renders Map/Set as {}. Convert any that reach details
+  // nested inside objects; top-level args already arrive as arrays in _maps/_sets.
+  private static replacer(_key: string, value: any) {
+    if (value instanceof Map) return Array.from(value)
+    if (value instanceof Set) return Array.from(value)
+    return value
   }
 }

--- a/src/utils/log.reader.ts
+++ b/src/utils/log.reader.ts
@@ -63,6 +63,8 @@ export class LogReader {
       else if (msg instanceof Error) this.setError(info, new ErrorDetails(msg))
       else if (msg instanceof Date) info.push(this.formatter.date(msg, info))
       else if (Array.isArray(msg)) info.push(this.formatter.array(msg, info))
+      else if (msg instanceof Map) this.setMap(info, msg)
+      else if (msg instanceof Set) this.setSet(info, msg)
       else if (msg && typeof msg === 'object') info.details.assign(msg)
       else if (typeof msg === 'string' && !msg) continue
       else info.push(msg)
@@ -182,5 +184,15 @@ export class LogReader {
       info.details.setError(value)
       info.entity('error', value)
     }
+  }
+
+  private setMap(info: LogInfo, value: Map<any, any>) {
+    info.details.setMap(value)
+    info.push(this.formatter.map(value, info))
+  }
+
+  private setSet(info: LogInfo, value: Set<any>) {
+    info.details.setSet(value)
+    info.push(this.formatter.set(value, info))
   }
 }

--- a/src/utils/string.formatter.ts
+++ b/src/utils/string.formatter.ts
@@ -17,6 +17,12 @@ export class StringFormatter implements IFormatter {
   array(value: any[]) {
     return value
   }
+  map(value: Map<any, any>) {
+    return value
+  }
+  set(value: Set<any>) {
+    return value
+  }
   null(value: null | undefined) {
     return value
   }

--- a/src/utils/types.d.ts
+++ b/src/utils/types.d.ts
@@ -11,6 +11,8 @@ export interface IFormatter {
   bigint(value: bigint, info: LogInfo): string | bigint
   date(value: Date, info: LogInfo): string | Date
   array(value: any[], info: LogInfo): string | any[]
+  map(value: Map<any, any>, info: LogInfo): string | Map<any, any>
+  set(value: Set<any>, info: LogInfo): string | Set<any>
   null(value: null | undefined, info: LogInfo): string | null | undefined
 }
 


### PR DESCRIPTION
Map and Set arguments fell into the generic object branch in the reader and were merged via Object.keys, which is empty for them, so the data vanished. Route them before that branch: the console renders them with formatWithOptions, and the JSON formatter keeps a length-capped preview in the message while storing full contents in details._maps/_sets. Nested Map/Set inside logged objects are converted by a JSON.stringify replacer so they no longer serialize as {}.

Closes #36